### PR TITLE
Add limited support for selecting a currency symbol

### DIFF
--- a/src/components/AccountView/AccountAddModal.vue
+++ b/src/components/AccountView/AccountAddModal.vue
@@ -58,7 +58,7 @@
                 id="startingBalanceField"
                 v-model="editeditem.initialBalance"
                 label="Starting Balance"
-                prefix="$"
+                :prefix=currencySymbol
                 data-cy="account-starting-balance"
               />
             </v-col>
@@ -79,6 +79,7 @@
 
 <script>
 import BaseModalComponent from './../Modals/BaseModalComponent'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'AccountAddModal',
@@ -102,6 +103,7 @@ export default {
     valid: false
   }),
   computed: {
+    ...mapGetters(['currencySymbol']),
     show: {
       get() {
         return this.value
@@ -111,7 +113,6 @@ export default {
       }
     }
   },
-
   methods: {
     accountTypeChanged() {
       if (this.editeditem.type == 'CREDIT') {

--- a/src/components/BudgetView/BudgetGrid.vue
+++ b/src/components/BudgetView/BudgetGrid.vue
@@ -151,12 +151,12 @@
       <v-col sm="auto" class="px-0 py-1" />
       <v-col sm="auto" class="px-0 py-1">
         <div class="money-amount subtitle-2 pt-1">
-          {{ getSpentValue(null) | currency }}
+          {{ getSpentValue(null) | currency(currency) }}
         </div>
       </v-col>
       <v-col sm="auto" class="px-0 py-1">
         <div class="money-amount subtitle-2 red--text pt-1">
-          {{ getBalanceValue(null) | currency }}
+          {{ getBalanceValue(null) | currency(currency) }}
         </div>
       </v-col>
     </v-row>
@@ -285,7 +285,7 @@
                   'budgeted-amount-zero': getBudgetedValue(item._id) == 0
                 }"
                 :value="getBudgetedValue(item._id)"
-                prefix="$"
+                :prefix=currency
                 hide-details
                 @change="budgetValueChanged(item, $event)"
                 @focus="onFocus"
@@ -306,7 +306,7 @@
                   'grey--text': getSpentValue(item._id) == 0
                 }"
               >
-                {{ getSpentValue(item._id) | currency }}
+                {{ getSpentValue(item._id) | currency(currency) }}
               </div>
             </v-col>
 
@@ -319,7 +319,7 @@
                 }"
                 :category_uid="item._id"
               >
-                {{ getBalanceValue(item._id) | currency }}
+                {{ getBalanceValue(item._id) | currency(currency) }}
                 <v-btn icon x-small tabindex="-1" @click.stop="flipOverspending(item)">
                   <v-icon v-if="getOverspendingProperty(item)" color="red" tabindex="-1">
                     mdi-arrow-right
@@ -378,7 +378,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['selectedBudgetID', 'monthlyData', 'month_selected', 'month_category_lookup']),
+    ...mapGetters(['selectedBudgetID', 'monthlyData', 'month_selected', 'month_category_lookup', 'currency']),
     masterCategories: {
       get() {
         return this.$store.getters.masterCategories

--- a/src/components/BudgetView/BudgetGrid.vue
+++ b/src/components/BudgetView/BudgetGrid.vue
@@ -151,12 +151,12 @@
       <v-col sm="auto" class="px-0 py-1" />
       <v-col sm="auto" class="px-0 py-1">
         <div class="money-amount subtitle-2 pt-1">
-          {{ getSpentValue(null) | currency(currency) }}
+          {{ getSpentValue(null) | currency(currencySymbol) }}
         </div>
       </v-col>
       <v-col sm="auto" class="px-0 py-1">
         <div class="money-amount subtitle-2 red--text pt-1">
-          {{ getBalanceValue(null) | currency(currency) }}
+          {{ getBalanceValue(null) | currency(currencySymbol) }}
         </div>
       </v-col>
     </v-row>
@@ -285,7 +285,7 @@
                   'budgeted-amount-zero': getBudgetedValue(item._id) == 0
                 }"
                 :value="getBudgetedValue(item._id)"
-                :prefix=currency
+                :prefix=currencySymbol
                 hide-details
                 @change="budgetValueChanged(item, $event)"
                 @focus="onFocus"
@@ -306,7 +306,7 @@
                   'grey--text': getSpentValue(item._id) == 0
                 }"
               >
-                {{ getSpentValue(item._id) | currency(currency) }}
+                {{ getSpentValue(item._id) | currency(currencySymbol) }}
               </div>
             </v-col>
 
@@ -319,7 +319,7 @@
                 }"
                 :category_uid="item._id"
               >
-                {{ getBalanceValue(item._id) | currency(currency) }}
+                {{ getBalanceValue(item._id) | currency(currencySymbol) }}
                 <v-btn icon x-small tabindex="-1" @click.stop="flipOverspending(item)">
                   <v-icon v-if="getOverspendingProperty(item)" color="red" tabindex="-1">
                     mdi-arrow-right
@@ -378,7 +378,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['selectedBudgetID', 'monthlyData', 'month_selected', 'month_category_lookup', 'currency']),
+    ...mapGetters(['selectedBudgetID', 'monthlyData', 'month_selected', 'month_category_lookup', 'currencySymbol']),
     masterCategories: {
       get() {
         return this.$store.getters.masterCategories

--- a/src/components/BudgetView/BudgetHeader.vue
+++ b/src/components/BudgetView/BudgetHeader.vue
@@ -17,7 +17,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.available_to_budget_last_month / 100
-                    : 0 | currency
+                    : 0 | currency(currency)
                 }}
               </span>
             </p>
@@ -27,7 +27,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.income_this_month / 100
-                    : 0 | currency
+                    : 0 | currency(currency)
                 }}
               </span>
             </p>
@@ -37,7 +37,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.last_month_overspent / 100
-                    : 0 | currency
+                    : 0 | currency(currency)
                 }}
               </span>
             </p>
@@ -47,7 +47,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.budgeted_this_month / 100
-                    : 0 | currency
+                    : 0 | currency(currency)
                 }}
               </span>
             </p>
@@ -62,7 +62,7 @@
             {{
               monthlyData[month_selected]
                 ? monthlyData[month_selected].summaryData.available_to_budget_this_month / 100
-                : 0 | currency
+                : 0 | currency(currency)
             }}
           </div>
         </v-card-text>
@@ -80,13 +80,9 @@ export default {
     return {}
   },
   computed: {
-    ...mapGetters(['monthlyData', 'month_selected']),
+    ...mapGetters(['monthlyData', 'month_selected', 'currency']),
     doesMonthDataExist() {
-      if (this.monthlyData.hasOwnProperty(`${this.month_selected}`)) {
-        return true
-      } else {
-        return false
-      }
+      return this.monthlyData.hasOwnProperty(`${this.month_selected}`)
     }
   },
   methods: {}

--- a/src/components/BudgetView/BudgetHeader.vue
+++ b/src/components/BudgetView/BudgetHeader.vue
@@ -17,7 +17,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.available_to_budget_last_month / 100
-                    : 0 | currency(currency)
+                    : 0 | currency(currencySymbol)
                 }}
               </span>
             </p>
@@ -27,7 +27,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.income_this_month / 100
-                    : 0 | currency(currency)
+                    : 0 | currency(currencySymbol)
                 }}
               </span>
             </p>
@@ -37,7 +37,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.last_month_overspent / 100
-                    : 0 | currency(currency)
+                    : 0 | currency(currencySymbol)
                 }}
               </span>
             </p>
@@ -47,7 +47,7 @@
                 {{
                   monthlyData[month_selected]
                     ? monthlyData[month_selected].summaryData.budgeted_this_month / 100
-                    : 0 | currency(currency)
+                    : 0 | currency(currencySymbol)
                 }}
               </span>
             </p>
@@ -62,7 +62,7 @@
             {{
               monthlyData[month_selected]
                 ? monthlyData[month_selected].summaryData.available_to_budget_this_month / 100
-                : 0 | currency(currency)
+                : 0 | currency(currencySymbol)
             }}
           </div>
         </v-card-text>
@@ -80,7 +80,7 @@ export default {
     return {}
   },
   computed: {
-    ...mapGetters(['monthlyData', 'month_selected', 'currency']),
+    ...mapGetters(['monthlyData', 'month_selected', 'currencySymbol']),
     doesMonthDataExist() {
       return this.monthlyData.hasOwnProperty(`${this.month_selected}`)
     }

--- a/src/components/Manage.vue
+++ b/src/components/Manage.vue
@@ -125,6 +125,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import BaseDialogModalComponent from './Modals/BaseDialogModalComponent.vue'
+import { symbols } from '../helper.js'
 
 export default {
   name: 'Settings',
@@ -137,10 +138,7 @@ export default {
       manageBudgetsModalVisible: false,
       dialog: false,
       item: {},
-      currencies: [
-        { value: 'USD', text: '$' }
-        // { value: "USD2", text: "$2" }
-      ]
+      currencies: symbols.map(({ key, value }) => ({ value: key, text: value }))
     }
   },
   computed: {

--- a/src/components/Reports/LineChart.vue
+++ b/src/components/Reports/LineChart.vue
@@ -8,6 +8,7 @@
 
 <script>
 import Chart from 'chart.js/auto'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'LineChart',
@@ -17,7 +18,9 @@ export default {
       chart: null
     }
   },
-  computed: {},
+  computed: {
+    ...mapGetters(['currency'])
+  },
   watch: {
     chartData: function() {
       console.log('changed')
@@ -77,8 +80,8 @@ export default {
             y: {
               ticks: {
                 // Include a dollar sign in the ticks
-                callback: function(value, index, values) {
-                  return '$' + value
+                callback: (value, index, values) => {
+                  return this.$options.filters.currency(value, this.currency);
                 }
               }
             }
@@ -95,7 +98,7 @@ export default {
                   if (context.parsed.y !== null) {
                     label += new Intl.NumberFormat('en-US', {
                       style: 'currency',
-                      currency: 'USD'
+                      currency: this.currency
                     }).format(context.parsed.y)
                   }
                   return label

--- a/src/components/Reports/LineChart.vue
+++ b/src/components/Reports/LineChart.vue
@@ -19,7 +19,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['currency'])
+    ...mapGetters(['currencySymbol', 'currencyCode'])
   },
   watch: {
     chartData: function() {
@@ -81,7 +81,7 @@ export default {
               ticks: {
                 // Include a dollar sign in the ticks
                 callback: (value, index, values) => {
-                  return this.$options.filters.currency(value, this.currency);
+                  return this.$options.filters.currency(value, this.currencySymbol);
                 }
               }
             }
@@ -89,16 +89,15 @@ export default {
           plugins: {
             tooltip: {
               callbacks: {
-                label: function(context) {
+                label: (context) => {
                   var label = context.dataset.label || ''
-
                   if (label) {
                     label += ': '
                   }
                   if (context.parsed.y !== null) {
                     label += new Intl.NumberFormat('en-US', {
                       style: 'currency',
-                      currency: this.currency
+                      currency: this.currencyCode
                     }).format(context.parsed.y)
                   }
                   return label

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -140,7 +140,7 @@
       <!-- <v-list-group value="true">
         <template v-slot:activator> -->
       <v-list-item-title class="pl-2 pt-1 pb-1 font-weight-medium subtitle-2 blue-grey--text text--lighten-3">
-        ON BUDGET <span class="float-right pr-4">{{ sumOfOnBudgetAccounts | currency(currency) }}</span>
+        ON BUDGET <span class="float-right pr-4">{{ sumOfOnBudgetAccounts | currency(currencySymbol) }}</span>
       </v-list-item-title>
 
       <!-- </template> -->
@@ -159,7 +159,7 @@
           </v-list-item-title>
         </v-list-item-content>
         <v-list-item-icon class="subtitle-2">
-          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currency) }}
+          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currencySymbol) }}
         </v-list-item-icon>
       </v-list-item>
 
@@ -168,7 +168,7 @@
       <!-- <v-list-group value="true">
         <template v-slot:activator> -->
       <v-list-item-title class="pl-2 pt-1 pb-1 font-weight-medium subtitle-2 blue-grey--text text--lighten-3">
-        OFF BUDGET <span class="float-right pr-4">{{ sumOfOffBudgetAccounts | currency(currency) }}</span>
+        OFF BUDGET <span class="float-right pr-4">{{ sumOfOffBudgetAccounts | currency(currencySymbol) }}</span>
       </v-list-item-title>
       <!-- </template> -->
 
@@ -185,7 +185,7 @@
           </v-list-item-title>
         </v-list-item-content>
         <v-list-item-icon class="subtitle-2">
-          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currency) }}
+          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currencySymbol) }}
         </v-list-item-icon>
       </v-list-item>
 
@@ -306,7 +306,7 @@ export default {
       'budgetRoots',
       'budgetRootsMap',
       'user',
-      'currency'
+      'currencySymbol'
     ]),
     budgetName() {
       if (this.selectedBudget) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -140,7 +140,7 @@
       <!-- <v-list-group value="true">
         <template v-slot:activator> -->
       <v-list-item-title class="pl-2 pt-1 pb-1 font-weight-medium subtitle-2 blue-grey--text text--lighten-3">
-        ON BUDGET <span class="float-right pr-4">{{ sumOfOnBudgetAccounts | currency }}</span>
+        ON BUDGET <span class="float-right pr-4">{{ sumOfOnBudgetAccounts | currency(currency) }}</span>
       </v-list-item-title>
 
       <!-- </template> -->
@@ -159,7 +159,7 @@
           </v-list-item-title>
         </v-list-item-content>
         <v-list-item-icon class="subtitle-2">
-          {{ (account_balances[item._id.slice(-36)].working / 100) | currency }}
+          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currency) }}
         </v-list-item-icon>
       </v-list-item>
 
@@ -168,7 +168,7 @@
       <!-- <v-list-group value="true">
         <template v-slot:activator> -->
       <v-list-item-title class="pl-2 pt-1 pb-1 font-weight-medium subtitle-2 blue-grey--text text--lighten-3">
-        OFF BUDGET <span class="float-right pr-4">{{ sumOfOffBudgetAccounts | currency }}</span>
+        OFF BUDGET <span class="float-right pr-4">{{ sumOfOffBudgetAccounts | currency(currency) }}</span>
       </v-list-item-title>
       <!-- </template> -->
 
@@ -185,7 +185,7 @@
           </v-list-item-title>
         </v-list-item-content>
         <v-list-item-icon class="subtitle-2">
-          {{ (account_balances[item._id.slice(-36)].working / 100) | currency }}
+          {{ (account_balances[item._id.slice(-36)].working / 100) | currency(currency) }}
         </v-list-item-icon>
       </v-list-item>
 
@@ -305,7 +305,8 @@ export default {
       'selectedBudgetID',
       'budgetRoots',
       'budgetRootsMap',
-      'user'
+      'user',
+      'currency'
     ]),
     budgetName() {
       if (this.selectedBudget) {

--- a/src/components/TransactionView/ReconcileHeader.vue
+++ b/src/components/TransactionView/ReconcileHeader.vue
@@ -8,7 +8,7 @@
       <template #body>
         <span class="subtitle-1"
           >There is a difference between your cleared balance and your bank balance. If you continue this will create an
-          adjustment transaction of <v-chip>{{ -parseInt(differenceAmount) | currency }}</v-chip></span
+          adjustment transaction of <v-chip>{{ -parseInt(differenceAmount) | currency(currencySymbol) }}</v-chip></span
         >
       </template>
       <template #actions>
@@ -24,7 +24,7 @@
     <v-col sm="auto" class="pa-0">
       <v-card flat class="grey lighten-1">
         <v-card-title class="title font-weight-bold primary--text">
-          {{ (selected_account_balance.cleared / 100) | currency }}<br />
+          {{ (selected_account_balance.cleared / 100) | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2 primary--text">CLEARED</span>
@@ -37,7 +37,7 @@
     <v-col sm="auto" class="pa-0">
       <v-card flat class="grey lighten-1">
         <v-card-title class="title font-weight-bold primary--text">
-          {{ reconcileAmount | currency }}<br />
+          {{ reconcileAmount | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2 primary--text">STATEMENT</span>
@@ -50,7 +50,7 @@
     <v-col class="pa-0" sm="auto">
       <v-card flat class="grey lighten-1">
         <v-card-title class="title font-weight-bold primary--text">
-          {{ differenceAmount | currency }}<br />
+          {{ differenceAmount | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2 primary--text">DIFFERENCE</span>
@@ -89,7 +89,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['selectedBudgetID']),
+    ...mapGetters(['selectedBudgetID', 'currencySymbol']),
     selected_account_balance() {
       return this.$store.getters.account_balances[this.$route.params.account_id]
     },

--- a/src/components/TransactionView/TransactionHeader.vue
+++ b/src/components/TransactionView/TransactionHeader.vue
@@ -14,7 +14,7 @@
     <v-col sm="auto" class="pa-0">
       <v-card flat class="header_background">
         <v-card-title class="title font-weight-bold primary--text">
-          {{ (selected_account_balance.cleared / 100) | currency }}<br />
+          {{ (selected_account_balance.cleared / 100) | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2 grey--text text--darken-2">CLEARED</span>
@@ -29,7 +29,7 @@
     <v-col sm="auto" class="pa-0">
       <v-card flat class="header_background">
         <v-card-title class="title font-weight-bold primary--text">
-          {{ (selected_account_balance.uncleared / 100) | currency }}<br />
+          {{ (selected_account_balance.uncleared / 100) | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2">UNCLEARED</span>
@@ -44,7 +44,7 @@
     <v-col sm="auto" class="pa-0">
       <v-card flat class="header_background">
         <v-card-title class="headline-5 font-weight-bold primary--text">
-          {{ (selected_account_balance.cleared / 100 + selected_account_balance.uncleared / 100) | currency }}<br />
+          {{ (selected_account_balance.cleared / 100 + selected_account_balance.uncleared / 100) | currency(currencySymbol) }}<br />
         </v-card-title>
         <v-card-subtitle>
           <span class="subtitle-2 grey--text text--darken-2">WORKING BALANCE</span>
@@ -76,6 +76,7 @@
 
 <script>
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
 
 export default {
   props: ['selected_account'],
@@ -83,6 +84,7 @@ export default {
     return {}
   },
   computed: {
+    ...mapGetters(['currencySymbol']),
     selected_account_balance() {
       return this.$store.getters.account_balances[this.$store.state.route.params.account_id]
     }

--- a/src/components/TransactionView/Transactions.vue
+++ b/src/components/TransactionView/Transactions.vue
@@ -364,7 +364,7 @@
                         <v-list-item-action>
                           <!-- TODO: 'month_selected' should probably be the transaction month -->
                           <v-list-item-action-text>
-                            {{ (getBalance(item) / 100) | currency }}
+                            {{ (getBalance(item) / 100) | currency(currencySymbol) }}
                           </v-list-item-action-text>
                         </v-list-item-action>
                       </template>
@@ -412,7 +412,7 @@
                   <div class="editing-cell-container">
                     <v-text-field
                       v-model="inflowAmount"
-                      prefix="$"
+                      :prefix=currencySymbol
                       class="pa-0 pb-1 editing-cell-element"
                       color="green"
                       id="inflow-input"
@@ -422,7 +422,7 @@
                 </td>
                 <td v-else align="right" id="inflow">
                   <div>
-                    {{ item.value > 0 ? item.value / 100 : '' | currency }}
+                    {{ item.value > 0 ? item.value / 100 : '' | currency(currencySymbol) }}
                   </div>
                 </td>
 
@@ -431,7 +431,7 @@
                   <div class="editing-cell-container">
                     <v-text-field
                       v-model="outflowAmount"
-                      prefix="$"
+                      :prefix=currencySymbol
                       class="pa-0 pb-1 editing-cell-element"
                       color="red"
                       id="outflow-input"
@@ -441,7 +441,7 @@
                 </td>
                 <td v-else align="right" id="outflow">
                   <div>
-                    {{ item.value < 0 ? -(item.value / 100) : '' | currency }}
+                    {{ item.value < 0 ? -(item.value / 100) : '' | currency(currencySymbol) }}
                   </div>
                 </td>
 
@@ -689,7 +689,8 @@ export default {
       'selectedBudgetID',
       'transactions',
       'monthlyData',
-      'month_selected'
+      'month_selected',
+      'currencySymbol'
     ]),
     inflowAmount: {
       get() {

--- a/src/helper.js
+++ b/src/helper.js
@@ -4,4 +4,10 @@ function sanitizeValueInput(value) {
   return parseInt(amt) / 100
 }
 
-export { sanitizeValueInput }
+var symbols = {
+  USD: '$',
+  EUR: '€',
+  GBP: '£'
+}
+
+export { sanitizeValueInput, symbols }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,7 +24,8 @@ export default new Vuex.Store({
     sync_state: '',
     selectedBudgetID: null,
     month_selected: moment(new Date()).format('YYYY-MM'),
-    currency: 'USD'
+    currencySymbol: '$',
+    currencyCode: 'USD'
   },
   getters: {
     snackbarMessage: state => state.snackbarMessage,
@@ -33,7 +34,8 @@ export default new Vuex.Store({
     snackbar: state => state.snackbar,
     selectedBudgetID: state => state.selectedBudgetID,
     month_selected: state => state.month_selected,
-    currency: state => state.currency
+    currencySymbol: state => state.currencySymbol,
+    currencyCode: state => state.currencyCode
   },
   mutations: {
     SET_STATUS_MESSAGE(state, message) {
@@ -70,7 +72,8 @@ export default new Vuex.Store({
       this.dispatch('setCurrency', state.selectedBudgetID)
     },
     SET_CURRENCY(state, payload) {
-      state.currency = symbols[payload] !== undefined ? symbols[payload] : '$'
+      state.currencySymbol = symbols[payload] !== undefined ? symbols[payload] : '$'
+      state.currencyCode = payload
     }
   },
   actions: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import budget from './modules/budget-module'
 import reports from './modules/reports-module'
 import pouchdb from './modules/pouchdb-module'
 import moment from 'moment'
+import { symbols } from '../helper.js'
 
 Vue.use(Vuex)
 
@@ -22,7 +23,8 @@ export default new Vuex.Store({
     snackbar: false,
     sync_state: '',
     selectedBudgetID: null,
-    month_selected: moment(new Date()).format('YYYY-MM')
+    month_selected: moment(new Date()).format('YYYY-MM'),
+    currency: 'USD'
   },
   getters: {
     snackbarMessage: state => state.snackbarMessage,
@@ -30,7 +32,8 @@ export default new Vuex.Store({
     sync_state: state => state.sync_state,
     snackbar: state => state.snackbar,
     selectedBudgetID: state => state.selectedBudgetID,
-    month_selected: state => state.month_selected
+    month_selected: state => state.month_selected,
+    currency: state => state.currency
   },
   mutations: {
     SET_STATUS_MESSAGE(state, message) {
@@ -62,6 +65,12 @@ export default new Vuex.Store({
     UPDATE_SELECTED_BUDGET(state, payload) {
       state.selectedBudgetID = payload
       localStorage.budgetID = payload
+    },
+    SET_BUDGET_OPENED(state, payload) {
+      this.dispatch('setCurrency', state.selectedBudgetID)
+    },
+    SET_CURRENCY(state, payload) {
+      state.currency = symbols[payload] !== undefined ? symbols[payload] : '$'
     }
   },
   actions: {
@@ -71,6 +80,9 @@ export default new Vuex.Store({
     setSelectedBudgetID(context, payload) {
       context.commit('UPDATE_SELECTED_BUDGET', payload)
       context.dispatch('loadLocalBudgetRoot')
+    },
+    setCurrency(context, payload) {
+      context.commit('SET_CURRENCY', context.getters.budgetRootsMap[payload].currency)
     }
   }
 })


### PR DESCRIPTION
I noticed the `currency` filter was used, so I added some logic to utilize to existing drop-down to store and pass a currency symbol.